### PR TITLE
IO landing mobile layout

### DIFF
--- a/messages/context.json
+++ b/messages/context.json
@@ -45,7 +45,7 @@
   "io.startbuilding.title": "Start building the future of commerce.",
   "io.startbuilding.text": "Build apps with cutting-edge technology, meet the needs of world-class brands and expand the possibilities of retail.",
   "io.startbuilding.cta": "BECOME A PARTNER",
-  "io.footer.vtex": "VTEX - The True Cloud Commerce ™ Platform. We manage billions of sessions with an estimated GMV of over $2 billion across 2.000 stores.",
+  "io.footer.vtex": "Accelerating Commerce Transformation.",
   "io.footer.pricing": "Pricing",
   "io.footer.company": "Company",
   "io.footer.company.carrers": "Carrers",

--- a/messages/context.json
+++ b/messages/context.json
@@ -1,4 +1,5 @@
 {
+  "io.page-title": "VTEX IO",
   "io.navbar.learn": "Learn",
   "io.navbar.make": "Make",
   "io.navbar.keepup": "Keep Up",

--- a/messages/en.json
+++ b/messages/en.json
@@ -45,7 +45,7 @@
   "io.startbuilding.title": "Start building the future of commerce.",
   "io.startbuilding.text": "Build apps with cutting-edge technology, meet the needs of world-class brands and expand the possibilities of retail.",
   "io.startbuilding.cta": "BECOME A PARTNER",
-  "io.footer.vtex": "VTEX - The True Cloud Commerce ™ Platform. We manage billions of sessions with an estimated GMV of over $2 billion across 2.000 stores.",
+  "io.footer.vtex": "Accelerating Commerce Transformation.",
   "io.footer.pricing": "Pricing",
   "io.footer.company": "Company",
   "io.footer.company.carrers": "Carrers",

--- a/react/IO.tsx
+++ b/react/IO.tsx
@@ -1,4 +1,6 @@
 import React, { Fragment, FunctionComponent } from 'react'
+import { injectIntl, InjectedIntlProps } from 'react-intl'
+import { Helmet } from 'vtex.render-runtime'
 
 import Navbar from './components/IOLanding/Navbar'
 import Hero from './components/IOLanding/Hero'
@@ -9,10 +11,20 @@ import EvolutionSection from './components/IOLanding/Evolution'
 import KeyFeatures from './components/IOLanding/KeyFeatures'
 import StartBuilding from './components/IOLanding/StartBuilding'
 import Footer from './components/IOLanding/Footer'
+import favicon from './images/favicon.png'
 
-const Landing: FunctionComponent = () => {
+const Landing: FunctionComponent<InjectedIntlProps> = ({ intl }) => {
   return (
     <Fragment>
+      <Helmet>
+        <title>{intl.formatMessage({ id: 'io.page-title' })}</title>
+        <meta
+          name="description"
+          content="A serverless development platform from VTEX."
+        />
+        <meta name="theme-color" content="#F71963" />
+        <link rel="icon" href={favicon} />
+      </Helmet>
       <Navbar />
       <main className="w-100">
         <Hero />
@@ -28,4 +40,4 @@ const Landing: FunctionComponent = () => {
   )
 }
 
-export default Landing
+export default injectIntl(Landing)

--- a/react/components/IOLanding/Card.tsx
+++ b/react/components/IOLanding/Card.tsx
@@ -13,7 +13,7 @@ const Card: FunctionComponent<Props> = ({ icon, title, text, index }) => {
     <article
       className={`flex justify-between bg-muted-1 mv3 ${
         index % 2 === 0 ? 'mr3-m' : 'ml3-m'
-      } items-center ph6 pv5 w-40 br3`}
+      } items-center ph6 pv5 w-40-l br3`}
     >
       <div className="mr7">{icon}</div>
       <div>

--- a/react/components/IOLanding/Evolution.tsx
+++ b/react/components/IOLanding/Evolution.tsx
@@ -5,12 +5,12 @@ import CodeSampleImage from '../../images/CodeSample.svg'
 import BackgroundEffects from '../../images/BackgroundEffects.svg'
 
 const EvolutionSection = () => (
-  <section className="flex flex-column flex-row-l items-center vh-100-l ph9-ns">
+  <section className="flex flex-column flex-row-l items-center vh-100-l">
     <div
       className="c-muted-1 w-50-l w-100 h-75 bg-muted-3 flex justify-center items-center order-1 order-0-l"
       style={{ backgroundImage: `url(${BackgroundEffects})` }}
     >
-      <img src={CodeSampleImage} className="z-5 c-muted-1" alt="code-sample" />
+      <img src={CodeSampleImage} className="c-muted-1 z-4" alt="code-sample" />
     </div>
     <div className="w-90-s center w-50-l w-100-s pl10-l flex flex-column justify-center">
       <div className="order-0 order-1-l w-90 center mh7">

--- a/react/components/IOLanding/Evolution.tsx
+++ b/react/components/IOLanding/Evolution.tsx
@@ -5,29 +5,33 @@ import CodeSampleImage from '../../images/CodeSample.svg'
 import BackgroundEffects from '../../images/BackgroundEffects.svg'
 
 const EvolutionSection = () => (
-  <section className="flex vh-100 ph9">
+  <section className="flex flex-column flex-row-l items-center vh-100-l ph9-ns">
     <div
-      className="w-50 h-75 bg-muted-3 flex justify-center items-center"
+      className="c-muted-1 w-50-l w-100 h-75 bg-muted-3 flex justify-center items-center order-1 order-0-l"
       style={{ backgroundImage: `url(${BackgroundEffects})` }}
     >
       <img src={CodeSampleImage} className="z-5 c-muted-1" alt="code-sample" />
     </div>
-    <div className="c-muted-1 h-75 w-50 pl10 flex flex-column justify-center">
-      <p className="c-muted-1 t-small w-90">
-        <FormattedMessage id="io.evolution.focus" />
-      </p>
-      <p className="c-muted-1 f1 mt1 mb1 w-75">
-        <FormattedMessage id="io.evolution.evolution" />
-      </p>
-      <p className="c-muted-1 t-body w-90 lh-copy mb7">
-        <FormattedMessage id="io.evolution.perspective" />
-      </p>
-      <p className="c-muted-1 t-body w-90 mt7 mb2">
-        <FormattedMessage id="io.evolution.vtexio" />
-      </p>
-      <p className="c-muted-1 t-body w-90 lh-copy">
-        <FormattedMessage id="io.evolution.vtexio.description" />
-      </p>
+    <div className="w-90-s center w-50-l w-100-s pl10-l flex flex-column justify-center">
+      <div className="order-0 order-1-l w-90 center mh7">
+        <p className="c-muted-1 t-small w-90">
+          <FormattedMessage id="io.evolution.focus" />
+        </p>
+        <p className="c-muted-1 f1 mt1 mb1 w-75">
+          <FormattedMessage id="io.evolution.evolution" />
+        </p>
+        <p className="c-muted-1 t-body w-90 lh-copy mb7">
+          <FormattedMessage id="io.evolution.perspective" />
+        </p>
+      </div>
+      <div className="order-2-s w-90 center mh7">
+        <p className="c-muted-1 t-body w-90 mt7 mb2">
+          <FormattedMessage id="io.evolution.vtexio" />
+        </p>
+        <p className="c-muted-1 t-body w-90 lh-copy">
+          <FormattedMessage id="io.evolution.vtexio.description" />
+        </p>
+      </div>
     </div>
   </section>
 )

--- a/react/components/IOLanding/Footer.tsx
+++ b/react/components/IOLanding/Footer.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { FunctionComponent } from 'react'
 import { FormattedMessage } from 'react-intl'
 
 import Logo from '../../images/VTEX_footer.svg'
@@ -31,38 +31,38 @@ const footerLinks = [
   },
 ]
 
-const Footer = () => (
-  <footer className="bg-base pa10 c-muted-1">
-    <div className="flex justify-between">
-      <div className="w-33">
+const Footer: FunctionComponent = () => (
+  <footer className="bg-base pa10-l pv7 c-muted-1">
+    <div className="flex flex-wrap justify-between">
+      <div className="w-33-l ph4 ph0-l">
         <img src={Logo} alt="VTEX" />
-        <p>
+        <p className="flex">
           <FormattedMessage id="io.footer.vtex" />
         </p>
       </div>
-
-      {footerLinks.map(category => {
-        const baseMessageId = `io.footer.${category.id}`
-        return (
-          <ul key={category.id}>
-            <p className="fw7">
-              <FormattedMessage id={baseMessageId} />
-            </p>
-            {category.options.map(option => (
-              <li className="list" key={option}>
-                <p>
-                  <FormattedMessage id={`${baseMessageId}.${option}`} />
-                </p>
-              </li>
-            ))}
-          </ul>
-        )
-      })}
+      <div className="flex-l flex-wrap dn-s">
+        {footerLinks.map(category => {
+          const baseMessageId = `io.footer.${category.id}`
+          return (
+            <ul key={category.id}>
+              <p className="fw7">
+                <FormattedMessage id={baseMessageId} />
+              </p>
+              {category.options.map(option => (
+                <li className="list" key={option}>
+                  <p>
+                    <FormattedMessage id={`${baseMessageId}.${option}`} />
+                  </p>
+                </li>
+              ))}
+            </ul>
+          )
+        })}
+      </div>
     </div>
-    <p className="fw7">© VTEX, 2018</p>
     <div className="flex flex-wrap center mv7">
       {VTEXOffices.Offices.map(office => (
-        <div key={office.short} className="ph4 w-20">
+        <div key={office.short} className="ph4 w-20-ns w-50-s">
           <p className="t-heading-3">{office.short}</p>
           <p>{office.address1}</p>
           <p>{office.address2}</p>

--- a/react/components/IOLanding/Footer.tsx
+++ b/react/components/IOLanding/Footer.tsx
@@ -37,7 +37,7 @@ const Footer = () => (
       <div className="w-33">
         <img src={Logo} alt="VTEX" />
         <p>
-          <FormattedMessage id="footer.vtex" />
+          <FormattedMessage id="io.footer.vtex" />
         </p>
       </div>
 

--- a/react/components/IOLanding/Hero.tsx
+++ b/react/components/IOLanding/Hero.tsx
@@ -10,7 +10,10 @@ const Hero: FunctionComponent = () => {
       className="mb5 pt6 pb8 bg-base c-muted-1 flex flex-column items-center justify-center"
       style={{ backgroundImage: `url(${Brands})` }}
     >
-      <p className="tc w-40 mb0 t-heading-1 normal">
+      <p
+        className="tc w-40-ns mb0 t-heading-1 normal"
+        style={{ fontSize: '5rem' }}
+      >
         <FormattedMessage id="io.hero.globalbrands" />
       </p>
       <p className="w-40 t-body tc mv6">

--- a/react/components/IOLanding/Hero.tsx
+++ b/react/components/IOLanding/Hero.tsx
@@ -11,7 +11,7 @@ const Hero: FunctionComponent = () => {
       style={{ backgroundImage: `url(${Brands})` }}
     >
       <p
-        className="tc w-40-ns mb0 t-heading-1 normal"
+        className="tc w-40-ns mb0 mt10 t-heading-1 normal"
         style={{ fontSize: '5rem' }}
       >
         <FormattedMessage id="io.hero.globalbrands" />

--- a/react/components/IOLanding/HowItWorks.tsx
+++ b/react/components/IOLanding/HowItWorks.tsx
@@ -7,8 +7,8 @@ import AppStore from './icons/AppStore'
 
 const HowItWorks: FunctionComponent<InjectedIntlProps> = ({ intl }) => {
   return (
-    <section className="flex items-center justify-between w-90 vh-75 center c-muted-1">
-      <article className="mh7">
+    <section className="flex flex-column flex-row-l items-center justify-between w-90 vh-75-l center c-muted-1 mv7">
+      <article className="mh7-l mv5 mv0-l">
         <Stack />
         <p className="t-body mb3">
           {intl.formatMessage({ id: 'io.howitworks.appstore.scale' })}
@@ -20,7 +20,7 @@ const HowItWorks: FunctionComponent<InjectedIntlProps> = ({ intl }) => {
           {intl.formatMessage({ id: 'io.howitworks.appstore.solutions' })}
         </p>
       </article>
-      <article className="mh7">
+      <article className="mh7-l mv5 mv0-l">
         <Branches />
         <p className="t-body mb3">
           {intl.formatMessage({ id: 'io.howitworks.abtesting.decisions' })}
@@ -32,7 +32,7 @@ const HowItWorks: FunctionComponent<InjectedIntlProps> = ({ intl }) => {
           {intl.formatMessage({ id: 'io.howitworks.abtesting.tests' })}
         </p>
       </article>
-      <article className="mh7">
+      <article className="mh7-l mv5 mv0-l">
         <AppStore />
         <p className="t-body mb3">
           {intl.formatMessage({ id: 'io.howitworks.storeframework.build' })}

--- a/react/components/IOLanding/KeyFeatures.tsx
+++ b/react/components/IOLanding/KeyFeatures.tsx
@@ -7,15 +7,15 @@ import Serverless from './icons/Serverless'
 import Sync from './icons/Sync'
 
 const KeyFeatures = () => (
-  <section className="vh-100 bg-base c-muted-1 center w-90">
+  <section className="mv9 mt5-l vh-75-l bg-base c-muted-1 center w-90">
     <p className="mb0">
       <FormattedMessage id="io.features.title.small" />
     </p>
-    <p className="t-heading-1 normal w-50 mt3">
+    <p className="t-heading-1 normal w-50-ns mt3">
       <FormattedMessage id="io.features.title" />
     </p>
-    <div className="flex items-center justify-between">
-      <article className="mh7">
+    <div className="flex flex-column flex-row-l items-center justify-between">
+      <article className="mh7-l mv5 mv0-l">
         <Sync />
         <p className="f4">
           <FormattedMessage id="io.features.cloud" />
@@ -24,7 +24,7 @@ const KeyFeatures = () => (
           <FormattedMessage id="io.features.cloud.description" />
         </p>
       </article>
-      <article className="mh7">
+      <article className="mh7-l mv5 mv0-l">
         <Lightbulb />
         <p className="f4">
           <FormattedMessage id="io.features.setupless" />
@@ -33,7 +33,7 @@ const KeyFeatures = () => (
           <FormattedMessage id="io.features.setupless.description" />
         </p>
       </article>
-      <article className="mh7">
+      <article className="mh7-l mv5 mv0-l">
         <Workspaces />
         <p className="f4">
           <FormattedMessage id="io.features.workspaces" />
@@ -42,7 +42,7 @@ const KeyFeatures = () => (
           <FormattedMessage id="io.features.workspaces.description" />
         </p>
       </article>
-      <article className="mh7">
+      <article className="mh7-l mv5 mv0-l">
         <Serverless />
         <p className="f4">
           <FormattedMessage id="io.features.serverless" />

--- a/react/components/IOLanding/Navbar.tsx
+++ b/react/components/IOLanding/Navbar.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, useState } from 'react'
 import { InjectedIntlProps, injectIntl } from 'react-intl'
-import { IconCaretDown, IconCaretUp } from 'vtex.styleguide'
+import { IconCaretDown, IconCaretUp, IconBars } from 'vtex.styleguide'
 import { useRuntime } from 'vtex.render-runtime'
 
 import logoPath from '../../images/VTEX_Cold_Gray_RGB.svg'
@@ -19,68 +19,87 @@ const supportedLangs = [
 
 const Navbar: FunctionComponent<InjectedIntlProps> = ({ intl }) => {
   const { culture, emitter } = useRuntime()
-  const [open, setOpen] = useState(false)
+  const [openLocaleSelector, setOpenLocaleSelector] = useState(false)
+  const [openNav, setOpenNav] = useState(false)
   const [selectedLocale, setSelectedLocale] = useState(
     findLocale(culture.locale)
   )
 
   const handleLocaleClick = ({ target: { id } }: { target: any }) => {
     emitter.emit('localesChanged', id)
-    setOpen(false)
+    setOpenLocaleSelector(false)
     setSelectedLocale(findLocale(id))
   }
 
   return (
-    <nav>
-      <ul
-        className="w-100 flex flex-column flex-row-m justify-between list mt0 c-muted-1 items-center bg-base mb0 relative"
+    <nav className="flex">
+      <div
+        className="fixed bg-base c-muted-1 w-100 flex flex-column flex-row-l justify-between z-5"
         style={{
           boxShadow: `0px 3px 20px rgba(0, 0, 0, 0.3)`,
         }}
       >
-        <div className="flex items-center">
-          <img src={logoPath} className="h3" alt="VTEX" />
-          <p>|</p>
-          <p className="ml3">Developer</p>
+        <div className="flex justify-between">
+          <button
+            className="dn-l bg-base c-on-base w-33 w-50-l bn"
+            onClick={() => setOpenNav(!openNav)}
+          >
+            <IconBars />
+          </button>
+          <div className="flex items-center w-40 w-50-l">
+            <img src={logoPath} className="h3" alt="VTEX" />
+            <p className="dn-s flex-l">|</p>
+            <p className="dn-s flex-l ml3">Developer</p>
+          </div>
+          <button className="c-muted-1 bg-rebel-pink bn t-body w-25 dn-l">
+            {intl.formatMessage({ id: 'io.navbar.build' })}
+          </button>
         </div>
-        <div className="flex flex-wrap items-center">
-          <li className="mh5">
-            {intl.formatMessage({ id: 'io.navbar.learn' })}
-          </li>
-          <li className="mh5">
-            {intl.formatMessage({ id: 'io.navbar.make' })}
-          </li>
-          <li className="mh5">
-            {intl.formatMessage({ id: 'io.navbar.keepup' })}
-          </li>
-          <li className="flex items-center">
-            <div className="h-100 relative w3">
-              <button
-                onClick={() => setOpen(!open)}
-                className="c-muted-1 bg-base bn flex items-center"
-              >
-                <p className="ttu mr4">{splitLocale(selectedLocale.id)}</p>
-                {open ? <IconCaretUp /> : <IconCaretDown />}
-              </button>
-              <div hidden={!open} className="z-5 bg-base pa3 absolute">
-                {supportedLangs.map(({ id }) => (
-                  <button
-                    className="tc ttu c-muted-1 pointer bn bg-base"
-                    onClick={handleLocaleClick}
-                    id={id}
-                    key={id}
-                  >
-                    {splitLocale(id)}
-                  </button>
-                ))}
+        <div className="flex-l" hidden={!openNav}>
+          <ul className="flex flex-column flex-row-l justify-center list mt0 items-center mb0 relative">
+            <li className="mh5 mv5 mv0-l">
+              {intl.formatMessage({ id: 'io.navbar.learn' })}
+            </li>
+            <li className="mh5 mv5 mv0-l">
+              {intl.formatMessage({ id: 'io.navbar.make' })}
+            </li>
+            <li className="mh5 mv5 mv0-l">
+              {intl.formatMessage({ id: 'io.navbar.keepup' })}
+            </li>
+            <li className="flex items-center">
+              <div className="h-100 relative w3">
+                <button
+                  onClick={() => setOpenLocaleSelector(!openLocaleSelector)}
+                  className="c-muted-1 bg-base bn flex items-center"
+                >
+                  <p className="ttu mr4">{splitLocale(selectedLocale.id)}</p>
+                  {openLocaleSelector ? <IconCaretUp /> : <IconCaretDown />}
+                </button>
+                <div
+                  hidden={!openLocaleSelector}
+                  className="z-4 bg-base pa3 absolute"
+                >
+                  {supportedLangs.map(({ id }) => (
+                    <button
+                      className="tc ttu c-muted-1 pointer bn bg-base"
+                      onClick={handleLocaleClick}
+                      id={id}
+                      key={id}
+                    >
+                      {splitLocale(id)}
+                    </button>
+                  ))}
+                </div>
               </div>
-            </div>
-            <div className="bg-rebel-pink pa6">
-              {intl.formatMessage({ id: 'io.navbar.build' })}
-            </div>
-          </li>
+            </li>
+            <li>
+              <button className="c-muted-1 bg-rebel-pink bn t-body pa6 dn flex-l">
+                {intl.formatMessage({ id: 'io.navbar.build' })}
+              </button>
+            </li>
+          </ul>
         </div>
-      </ul>
+      </div>
     </nav>
   )
 }

--- a/react/components/IOLanding/Navbar.tsx
+++ b/react/components/IOLanding/Navbar.tsx
@@ -33,7 +33,7 @@ const Navbar: FunctionComponent<InjectedIntlProps> = ({ intl }) => {
   return (
     <nav>
       <ul
-        className="flex flex-column flex-row-m justify-between list mt0 c-muted-1 items-center bg-base mb0 relative"
+        className="w-100 flex flex-column flex-row-m justify-between list mt0 c-muted-1 items-center bg-base mb0 relative"
         style={{
           boxShadow: `0px 3px 20px rgba(0, 0, 0, 0.3)`,
         }}
@@ -43,7 +43,7 @@ const Navbar: FunctionComponent<InjectedIntlProps> = ({ intl }) => {
           <p>|</p>
           <p className="ml3">Developer</p>
         </div>
-        <div className="flex items-center">
+        <div className="flex flex-wrap items-center">
           <li className="mh5">
             {intl.formatMessage({ id: 'io.navbar.learn' })}
           </li>

--- a/react/components/IOLanding/Product.tsx
+++ b/react/components/IOLanding/Product.tsx
@@ -5,15 +5,15 @@ import productImagePath from '../../images/Product.svg'
 
 const ProductDisplay: FunctionComponent = () => {
   return (
-    <section className="w-100 flex justify-between pv10 bg-base">
-      <div className="c-muted-1 flex flex-column justify-center w-33 pl9">
-        <p className="t-small">
+    <section className="w-100 flex flex-column flex-row-l justify-between pv10 bg-base">
+      <div className="c-muted-1 flex flex-column justify-center w-33-l pl9-l mh0-l">
+        <p className="t-small w-90 center left-l">
           <FormattedMessage id="io.product.deliver" />
         </p>
-        <p className="f1 mt1 mb1 w-90">
+        <p className="f1 mt1 mb1 w-90 center left-l">
           <FormattedMessage id="io.product.scale" />
         </p>
-        <p className="t-body w-90">
+        <p className="t-body w-90 center left-l">
           <FormattedMessage id="io.product.cloud" />
         </p>
       </div>

--- a/react/components/IOLanding/StartBuilding.tsx
+++ b/react/components/IOLanding/StartBuilding.tsx
@@ -5,16 +5,16 @@ import { Button } from 'vtex.styleguide'
 import IllustrationImage from '../../images/Illutration_02_blue.png'
 
 const StartBuilding = () => (
-  <section className="flex vh-100 c-muted-5 bg-muted-2">
-    <div className="w-50">
+  <section className="flex flex-row-m flex-column vh-100-l c-muted-5 bg-muted-2">
+    <div className="w-50-l flex-l dn-s">
       <img src={IllustrationImage} alt="" className="h-100 w-100" />
     </div>
-    <div className="w-50 h-100 flex flex-column justify-between items-center">
-      <p className="t-heading-1 w-50 normal h-50">
+    <div className="w-50-l h-100 flex flex-column justify-around items-center">
+      <p className="w-90 center t-heading-1 w-50-l normal">
         <FormattedMessage id="io.startbuilding.title" />
       </p>
-      <div className="w-50 h-50 flex flex-column justify-center pb4">
-        <p className="t-body mb7">
+      <div className="w-50-ns w-90-s flex flex-column justify-center pb4">
+        <p className="t-body mb7 w-100-s">
           <FormattedMessage id="io.startbuilding.text" />
         </p>
         <div className="w-75 mb5">

--- a/react/typings/vtex.styleguide.d.ts
+++ b/react/typings/vtex.styleguide.d.ts
@@ -1,8 +1,9 @@
 declare module 'vtex.styleguide' {
+  export const Alert
   export const Button
-  export const PageBlock
   export const ButtonWithIcon
+  export const PageBlock
   export const IconCaretDown
   export const IconCaretUp
-  export const Alert
+  export const IconBars
 }

--- a/styles/configs/style.json
+++ b/styles/configs/style.json
@@ -257,7 +257,7 @@
       "heading-1": {
         "fontFamily": "Fabriga, -apple-system, BlinkMacSystemFont, avenir next, avenir, helvetica neue, helvetica, ubuntu, roboto, noto, segoe ui, arial, sans-serif",
         "fontWeight": "700",
-        "fontSize": "5rem",
+        "fontSize": "3rem",
         "textTransform": "initial",
         "letterSpacing": "0"
       },


### PR DESCRIPTION
#### What is the purpose of this pull request?
Implement mobile layout for the VTEX IO landing page. 
Also, minor overall improvements and fixes.

#### What problem is this solving?
The layout was not responsive and was built for desktops. Now it is the other way around and should fit both :)

#### How should this be manually tested?

https://iolanding--vtexpages.myvtexdev.com/dev/io

#### Screenshots or example usage

<img width="357" alt="Screen Shot 2019-04-24 at 10 27 02" src="https://user-images.githubusercontent.com/27777263/56663025-88953080-667b-11e9-8dca-eccb88826787.png">


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
